### PR TITLE
RE: email issues

### DIFF
--- a/tk_based_lib/workflow.py
+++ b/tk_based_lib/workflow.py
@@ -1,4 +1,5 @@
 import functools
+from inspect import signature
 
 #global variable to store output of functions
 data = []
@@ -11,6 +12,9 @@ class Wrap():
             """ inner decorator, that is returned """
             @functools.wraps(func)
             def wrapper(self, *args, **kwargs):
+                wrapped_params = signature(func).parameters
+                kwargs = {k: v for k, v in kwargs.items() if k in wrapped_params}
+
                 # wrapper that can access the local variables of the wrapped function
                 out = func(self, *args, **kwargs)
                 data.append(out)

--- a/tk_based_lib/workflow.py
+++ b/tk_based_lib/workflow.py
@@ -38,7 +38,7 @@ class Workflow():
     wrap = Wrap()
 
     def __init__(self, *args, **kwargs) -> None:
-        pass
+        self.outputs = {}
 
     def run(self):
         """ executed at end to return all the workflow step output """
@@ -51,6 +51,11 @@ class Workflow():
         """ Dummy method to mimic pyiron-workflow"""
         obj = Picture()
         return obj
+
+    def __setattr__(self, key, value):
+        if isinstance(value, RShiftableOutput):
+            self.outputs[key] = value.value
+        super().__setattr__(key, value)
 
 
 class Picture():

--- a/tk_based_lib/workflow.py
+++ b/tk_based_lib/workflow.py
@@ -4,6 +4,16 @@ from inspect import signature
 #global variable to store output of functions
 data = []
 
+
+class RShiftableOutput:
+    def __init__(self, value):
+        self.value = value
+
+    def __rshift__(self, other):
+        print(f"{self} ({id(self)}) ignoring rshift to {other} ({id(other)})")
+        return other
+
+
 class Wrap():
     """ Wrapper class that defines the decorator """
     def as_function_node(self, _):
@@ -18,6 +28,7 @@ class Wrap():
                 # wrapper that can access the local variables of the wrapped function
                 out = func(self, *args, **kwargs)
                 data.append(out)
+                return RShiftableOutput(out)
             return wrapper
         return decoratorInner
 

--- a/tk_based_lib/workflow.py
+++ b/tk_based_lib/workflow.py
@@ -40,6 +40,6 @@ class Workflow():
 
 class Picture():
     """ Dummy picture class that does nothing than create a file that pyiron-workflow also creates """
-    def render(self, filename='', format=''):
+    def render(self, filename='', format='', **kwargs):
         with open(filename, 'w', encoding='utf-8') as fOut:
             fOut.write('Dummy method\n')

--- a/tk_based_lib/workflow.py
+++ b/tk_based_lib/workflow.py
@@ -32,13 +32,17 @@ class Wrap():
             return wrapper
         return decoratorInner
 
+class _LikePyironWorkflowOutputs(dict):
+    def to_value_dict(self):
+        return self
+
 
 class Workflow():
     """ Boilerplate = minimalistic workflow engine"""
     wrap = Wrap()
 
     def __init__(self, *args, **kwargs) -> None:
-        self.outputs = {}
+        self.outputs = _LikePyironWorkflowOutputs()
 
     def run(self):
         """ executed at end to return all the workflow step output """

--- a/workflows/sem.py
+++ b/workflows/sem.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from tk_based_lib.storage import Storage, step
 from tk_based_lib.sample import Sample
 try:
-    raise ImportError
     from pyiron_workflow import Workflow
 except ImportError:
     from tk_based_lib.workflow import Workflow
@@ -26,8 +25,7 @@ wf.step1 >> wf.step2 >> wf.step3
 wf.starting_nodes = [wf.step1]
 
 # footer, always the same
-out = wf.run()
-print('Output:\n  ','\n   '.join([str(i) for i in list(out.values())]))
+print('Output:\n  ','\n   '.join([f"{k}: {v}" for k, v in list(wf.outputs.to_value_dict().items())]))
 
 # wf.draw().render(view=True)               #plot to screen (creating pdf->viewer)
 wf.draw().render(filename="io_demo", format="png", cleanup=True) #plot to file

--- a/workflows/sem.py
+++ b/workflows/sem.py
@@ -1,5 +1,4 @@
 # head of workflow: always the same
-import os
 from pathlib import Path
 from tk_based_lib.storage import Storage, step
 from tk_based_lib.sample import Sample
@@ -33,5 +32,4 @@ out = wf.run()
 print('Output:\n  ','\n   '.join([str(i) for i in list(out.values())]))
 
 # wf.draw().render(view=True)               #plot to screen (creating pdf->viewer)
-wf.draw().render(filename="io_demo", format="png") #plot to file
-os.unlink('io_demo')
+wf.draw().render(filename="io_demo", format="png", cleanup=True) #plot to file

--- a/workflows/sem.py
+++ b/workflows/sem.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from tk_based_lib.storage import Storage, step
 from tk_based_lib.sample import Sample
 try:
+    raise ImportError
     from pyiron_workflow import Workflow
 except ImportError:
     from tk_based_lib.workflow import Workflow
@@ -21,10 +22,7 @@ wf.step2 = step(storage, sample, 'light microscopy', {}, run_after_init=True)
 
 wf.step3 = step(storage, sample, 'sem', {'voltage':'30'}, run_after_init=True)
 
-try:
-    wf.step1 >> wf.step2 >> wf.step3
-except:
-    pass
+wf.step1 >> wf.step2 >> wf.step3
 wf.starting_nodes = [wf.step1]
 
 # footer, always the same

--- a/workflows/sem.py
+++ b/workflows/sem.py
@@ -15,11 +15,11 @@ storage=Storage(proceduresLibrary)                                  # folder or 
 # body of workflow: this changes
 sample = Sample('FeAl')
 
-wf.step1 = step(storage, sample, 'polish', {})   #define step and link to storage for procedures
+wf.step1 = step(storage, sample, 'polish', {}, run_after_init=True)   #define step and link to storage for procedures
 
-wf.step2 = step(storage, sample, 'light microscopy', {})
+wf.step2 = step(storage, sample, 'light microscopy', {}, run_after_init=True)
 
-wf.step3 = step(storage, sample, 'sem', {'voltage':'30'})
+wf.step3 = step(storage, sample, 'sem', {'voltage':'30'}, run_after_init=True)
 
 try:
     wf.step1 >> wf.step2 >> wf.step3

--- a/workflows/semException.py
+++ b/workflows/semException.py
@@ -22,4 +22,4 @@ wf.step2 = step(storage, sample, 'light microscopy', {}, run_after_init=True)
 wf.step3 = step(storage, sample, 'sem', {'voltage':'30'}, run_after_init=True)
 
 # footer, always the same
-print(wf.output)  #Exception
+print(wf.outputs.to_value_dict())  #Exception


### PR DESCRIPTION
Hey @SteffenBrinckmann, here are some small adjustments addressing your questions. In reverse order:

> There is also still the issue of my sem.py leaving an io_demo file in the current folder. I guess pyiron wants to use the tempfile library of python ;-)

Yep, exactly. `Node.draw` passes cwd information over to `graphviz`. Thankfully, `graphviz` is nice enough to let us avoid the `os` import by specifying `.render(..., cleanup=True)` to get rid of the io_demo tempfile, so I cut a couple lines by doing that.

> In the repo, there is a file semException.py that throws the exception. I guess that helps.

Ah, that was just me being dumb again. I told you to use `wf.output`, but it's `wf.outputs` 🤦‍♂️ 

> Since the other option works, there is no need to have an alternative, especially since getting the output is more difficult.

I added both a return value from the minimal engine decorated functions, and an `outputs` field (using a special dummy class) so that for both engines `wf.outputs.to_value_dict()` gives something good.

> can you tell me where I have to define the `__rshift__` operator such that the minimalistic workflow engine does not throw exception in the `>>` line?

This was actually kind of tricky. Basically it needed to exist on whatever `wf.step1/2/3` were holding. Initially that was `None` because the minimalistic steps didn't return anything. It also doesn't work when they just return their output, because you can't assign `__rshift__` onto `list` (or probably other object types, but list is the returned data here). At the end of the day I just made the decorated function return an object that wraps the real return value but also allows rshifting.

Now that the data from each step is stored in `wf.outputs`, I think we no longer (in principle) need the `.workflows.data` global, but I left it there for now.

We need to be a little cautious, as the minimalistic engine isn't compatible with all valid `pyiron_workflow` workflows, and the `>>` and `.starting_nodes` definitions are basically ignored compared to the actual (eager/greedy) execution of the minimalistic steps, so it's possible to write un-true things without getting an error. But at least for this example, `sem.py` can now run equally well for both engines without any `try/except`!