### PR TITLE
autorun instead of run_after_init

### DIFF
--- a/workflow_example.py
+++ b/workflow_example.py
@@ -15,16 +15,16 @@ storage=Storage(proceduresLibrary)                                             #
 # body of workflow: this changes
 sample = Sample('AM_NA_05')
 
-wf.step1 = step(storage, sample, 'metallography', {}, run_after_init=True)   #define step and link to storage for procedures
-wf.step2 = step(storage, sample, 'light microscopy', {}, run_after_init=True)
-wf.step3 = step(storage, sample, 'tensile test', {}, run_after_init=True)
-wf.step4 = step(storage, sample, 'light microscopy', {}, run_after_init=True)
-wf.step5a = step(storage, sample, 'sem', {'voltage':'30'}, run_after_init=True)
-wf.step5b = step(storage, sample, 'sem', {'voltage':'30'}, run_after_init=True)
+wf.step1 = step(storage, sample, 'metallography', {}, autorun=True)   #define step and link to storage for procedures
+wf.step2 = step(storage, sample, 'light microscopy', {}, autorun=True)
+wf.step3 = step(storage, sample, 'tensile test', {}, autorun=True)
+wf.step4 = step(storage, sample, 'light microscopy', {}, autorun=True)
+wf.step5a = step(storage, sample, 'sem', {'voltage':'30'}, autorun=True)
+wf.step5b = step(storage, sample, 'sem', {'voltage':'30'}, autorun=True)
 
 tensile_test_file_name = [v  for k,v in list(wf.outputs.to_value_dict().items()) if 'step3' in k][0][1]
-wf.step6 = plot_curves(tensile_test_file_name, 'Strain (Gauge0)', 'Engr. Stress')
-wf.step7 = calc_YoungsModulus(tensile_test_file_name, 'Strain (Gauge0)', 'Engr. Stress')
+wf.step6 = plot_curves(tensile_test_file_name, 'Strain (Gauge0)', 'Engr. Stress', autorun=True)
+wf.step7 = calc_YoungsModulus(tensile_test_file_name, 'Strain (Gauge0)', 'Engr. Stress', autorun=True)
 
 wf.step1 >> wf.step2 >> wf.step3 >> wf.step4 >> wf.step5a >> wf.step5b >> wf.step6 >> wf.step7
 wf.starting_nodes = [wf.step1]


### PR DESCRIPTION
Hey @SteffenBrinckmann,

You mentioned in the meeting the other week wanting a code-lock until after the presentation, which is perfectly reasonable to me so no rush to merge this -- but here is an update so the code runs with the new (compatibility-breaking) `pyiron_workflow-0.10.0`. Namely, the keyword `run_after_init` has been replaced with the keyword `autorun`.